### PR TITLE
fix: missing macos build deps during linking stage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uiohook-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "uiohook-rs is a Rust wrapper for the libuiohook, providing cross-platform keyboard and mouse hooking capabilities."
 license = "GPL-3.0"

--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,9 @@ fn main() {
                 .file(libuiohook_dir.join("src/darwin/post_event.c"))
                 .file(libuiohook_dir.join("src/darwin/system_properties.c"))
                 .file(libuiohook_dir.join("src/darwin/input_helper.c"));
+
+                println!("cargo:rustc-link-lib=framework=CoreFoundation");
+                println!("cargo:rustc-link-lib=framework=CoreGraphics");
         }
         "windows" => {
             build


### PR DESCRIPTION
Added missing linkings for MacOS (`CoreFoundation` and `CoreGraphics`)