### PR TITLE
Fix: the AXIsProcessTrustedWithOptions never found bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ libc = "0.2"
 colored = "2.1"
 ctrlc = "3.4"
 thiserror = "1.0"
-core-foundation = "0.10.0"
+core-foundation = "0.10"
 
 [build-dependencies]
 bindgen = "0.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ libc = "0.2"
 colored = "2.1"
 ctrlc = "3.4"
 thiserror = "1.0"
+core-foundation = "0.10.0"
 
 [build-dependencies]
 bindgen = "0.69"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 - Low-level keyboard and mouse event handling
 - Easy-to-use Rust API
 
-**IMPORTANT**: This crate has not been tested on `MacOS` and `Windows` yet, please report any issues you encounter (likely to be compilation issues related to dependencies).
+**Note**: All examples have now been tested on macOS, Windows and Linux.  
+On macOS the examples have been updated to use the `CoreFoundation` run loop (`CFRunLoop`) for proper event dispatch and exit.
 
 ## Usage
 

--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,7 @@ fn main() {
 
             println!("cargo:rustc-link-lib=framework=CoreFoundation");
             println!("cargo:rustc-link-lib=framework=CoreGraphics");
+            println!("cargo:rustc-link-lib=framework=ApplicationServices");
         }
         "windows" => {
             build

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -161,7 +161,7 @@ fn main() {
     #[cfg(not(target_os = "macos"))]
     {
         while running.load(Ordering::SeqCst) {
-            std::thread::sleep(time::Duration::from_millis(100));
+            std::thread::sleep(std::time::Duration::from_millis(100));
         }
     }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,11 +1,15 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use uiohook_rs::hook::keyboard::{KeyboardEvent, KeyboardEventType};
 use uiohook_rs::hook::mouse::{MouseEvent, MouseEventType};
 use uiohook_rs::hook::wheel::WheelEvent;
 use uiohook_rs::{EventHandler, Uiohook, UiohookEvent};
 
-struct DemoHandler;
+struct DemoEventHandler {
+    running: Arc<AtomicBool>,
+}
 
-impl EventHandler for DemoHandler {
+impl EventHandler for DemoEventHandler {
     fn handle_event(&self, event: &UiohookEvent) {
         match event {
             UiohookEvent::Keyboard(keyboard_event) => {
@@ -17,29 +21,32 @@ impl EventHandler for DemoHandler {
             UiohookEvent::Wheel(wheel_event) => {
                 self.handle_wheel_event(wheel_event);
             }
-            _ => {}
+            UiohookEvent::HookEnabled => {
+                println!("Hook Enabled");
+            }
+            UiohookEvent::HookDisabled => {
+                println!("Hook Disabled");
+                self.running.store(false, Ordering::SeqCst);
+            }
         }
     }
 }
 
-impl DemoHandler {
+impl DemoEventHandler {
     fn handle_keyboard_event(&self, keyboard_event: &KeyboardEvent) {
         match keyboard_event.event_type {
             KeyboardEventType::Pressed | KeyboardEventType::Released => {
                 let event_type = match keyboard_event.event_type {
-                    KeyboardEventType::Pressed => "PRESSED",
-                    KeyboardEventType::Released => "RELEASED",
+                    KeyboardEventType::Pressed => format!("{:<8}", "PRESSED"),
+                    KeyboardEventType::Released => format!("{:<8}", "RELEASED"),
                     _ => unreachable!(),
                 };
 
                 let key_info = format!("{:?}", keyboard_event.key_code);
 
                 println!(
-                    "{:<8} | {:<17} | Code: {:<5} | Raw: {:<5}",
-                    event_type,
-                    key_info,
-                    keyboard_event.key_code as u16,
-                    keyboard_event.raw_code
+                    "{} | {:<17} | Code: {:<5} | Raw: {:<5}",
+                    event_type, key_info, keyboard_event.key_code as u16, keyboard_event.raw_code
                 );
             }
             KeyboardEventType::Typed => {
@@ -51,8 +58,8 @@ impl DemoHandler {
                     };
 
                     println!(
-                        "{:<8} | {:<17} | Code: {:<5} | Raw: {:<5}",
-                        "TYPED",
+                        "{} | {:<17} | Code: {:<5} | Raw: {:<5}",
+                        format!("{:<8}", "TYPED"),
                         char_display,
                         ch as u32,
                         keyboard_event.raw_code
@@ -64,11 +71,11 @@ impl DemoHandler {
 
     fn handle_mouse_event(&self, mouse_event: &MouseEvent) {
         let event_type = match mouse_event.event_type {
-            MouseEventType::Moved => "MOVED",
-            MouseEventType::Pressed => "PRESSED",
-            MouseEventType::Released => "RELEASED",
-            MouseEventType::Clicked => "CLICKED",
-            MouseEventType::Dragged => "DRAGGED",
+            MouseEventType::Moved => format!("{:<8}", "MOVED"),
+            MouseEventType::Pressed => format!("{:<8}", "PRESSED"),
+            MouseEventType::Released => format!("{:<8}", "RELEASED"),
+            MouseEventType::Clicked => format!("{:<8}", "CLICKED"),
+            MouseEventType::Dragged => format!("{:<8}", "DRAGGED"),
         };
 
         let details = format!(
@@ -78,8 +85,9 @@ impl DemoHandler {
         );
 
         println!(
-            "{:<8} | X: {:<5} | Y: {:<5} | {}",
+            "{} | {:<17} | X: {:<5} | Y: {:<5} | {}",
             event_type,
+            "Mouse",
             mouse_event.x,
             mouse_event.y,
             details
@@ -87,7 +95,7 @@ impl DemoHandler {
     }
 
     fn handle_wheel_event(&self, wheel_event: &WheelEvent) {
-        let event_type = "SCROLL";
+        let event_type = format!("{:<8}", "SCROLL");
 
         let details = format!(
             "Amount: {:<4} | Rotation: {:<4} | Direction: {:<9}",
@@ -101,8 +109,9 @@ impl DemoHandler {
         );
 
         println!(
-            "{:<8} | X: {:<5} | Y: {:<5} | {}",
+            "{} | {:<17} | X: {:<5} | Y: {:<5} | {}",
             event_type,
+            "Mouse Wheel",
             wheel_event.x,
             wheel_event.y,
             details
@@ -111,14 +120,54 @@ impl DemoHandler {
 }
 
 fn main() {
-    println!("Running... Press Ctrl-C to exit");
+    #[cfg(target_os = "macos")]
+    use core_foundation::runloop::{CFRunLoopGetMain, CFRunLoopStop, CFRunLoopRun};
 
-    let event_handler = DemoHandler;
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+
+    println!("Press Ctrl-C to exit");
+
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+        #[cfg(target_os = "macos")]
+        {
+            println!("Ctrl-C pressed, stopping CFRunLoop...");
+            unsafe {
+                CFRunLoopStop(CFRunLoopGetMain());
+            }
+        }
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let event_handler = DemoEventHandler {
+        running: running.clone(),
+    };
 
     let uiohook = Uiohook::new(event_handler);
 
     if let Err(e) = uiohook.run() {
         eprintln!("Failed to run uiohook: {}", e);
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        println!("Starting CFRunLoopRun on macOS main thread...");
+        unsafe {
+            CFRunLoopRun();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        while running.load(Ordering::SeqCst) {
+            std::thread::sleep(time::Duration::from_millis(100));
+        }
+    }
+
+    // Stop uiohook
+    if let Err(e) = uiohook.stop() {
+        eprintln!("Failed to stop uiohook: {}", e);
     }
 
     println!("Exiting...");

--- a/examples/demo_keyboard.rs
+++ b/examples/demo_keyboard.rs
@@ -61,6 +61,20 @@ fn main() {
 
     if let Err(e) = uiohook.run() {
         eprintln!("Failed to run uiohook: {}", e);
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        unsafe {
+            core_foundation::runloop::CFRunLoopRun();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
     }
 
     println!("Exiting...");

--- a/examples/demo_mouse.rs
+++ b/examples/demo_mouse.rs
@@ -46,6 +46,20 @@ fn main() {
 
     if let Err(e) = uiohook.run() {
         eprintln!("Failed to run uiohook: {}", e);
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        unsafe {
+            core_foundation::runloop::CFRunLoopRun();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
     }
 
     println!("Exiting...");

--- a/examples/demo_stop.rs
+++ b/examples/demo_stop.rs
@@ -31,8 +31,25 @@ fn main() {
         return;
     }
 
-    // Run for 5 seconds
-    thread::sleep(Duration::from_secs(5));
+    #[cfg(target_os = "macos")]
+    {
+        use core_foundation::runloop::{CFRunLoopGetMain, CFRunLoopStop, CFRunLoopRun};
+        thread::spawn(|| {
+            thread::sleep(Duration::from_secs(5));
+            println!("Stopping CFRunLoop...");
+            unsafe {
+                CFRunLoopStop(CFRunLoopGetMain());
+            }
+        });
+        println!("Starting CFRunLoopRun on macOS main thread...");
+        unsafe {
+            CFRunLoopRun();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        thread::sleep(Duration::from_secs(5));
+    }
 
     // Stop uiohook
     println!("Stopping uiohook...");

--- a/examples/demo_wheel.rs
+++ b/examples/demo_wheel.rs
@@ -45,6 +45,20 @@ fn main() {
 
     if let Err(e) = uiohook.run() {
         eprintln!("Failed to run uiohook: {}", e);
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        unsafe {
+            core_foundation::runloop::CFRunLoopRun();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
     }
 
     println!("Exiting...");

--- a/scripts/check_ax.c
+++ b/scripts/check_ax.c
@@ -1,0 +1,26 @@
+/* Only for testing MacOS API */
+#include <stdio.h>
+#include <dlfcn.h>
+
+// gcc -o check_ax check_ax.c -framework CoreFoundation -framework ApplicationServices
+int main(void) {
+    void *handle = dlopen("/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices", RTLD_NOW);
+    if (!handle) {
+        printf("dlopen failed: %s\n", dlerror());
+        return 1;
+    }
+    
+    dlerror();
+
+    void *axFunc = dlsym(handle, "AXIsProcessTrustedWithOptions");
+    char *error = dlerror();
+    if (error != NULL) {
+        printf("AXIsProcessTrustedWithOptions Not Found: %s\n", error);
+    } else {
+        printf("AXIsProcessTrustedWithOptions Found, Addr: %p\n", axFunc);
+    }
+    
+    dlclose(handle);
+    return 0;
+}
+

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -7,7 +7,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,8 @@
 //!
 //! This module defines the error types used throughout the uiohook-rs crate.
 
-use thiserror::Error;
 use std::result;
+use thiserror::Error;
 
 /// A specialized Result type for uiohook operations.
 pub type Result<T> = result::Result<T, UiohookError>;

--- a/src/hook/keyboard.rs
+++ b/src/hook/keyboard.rs
@@ -487,7 +487,6 @@ impl From<KeyCode> for u32 {
 /// let hook = Uiohook::new(MyHandler);
 /// key_tap(&hook, KeyCode::A, &[KeyCode::ShiftL]).expect("Failed to tap key");
 /// ```
-
 pub fn key_tap(uiohook: &Uiohook, key: KeyCode, modifiers: &[KeyCode]) -> Result<(), UiohookError> {
     // 1. Create keyboard events for pressing modifiers
     for &modifier in modifiers {

--- a/src/hook/wheel.rs
+++ b/src/hook/wheel.rs
@@ -54,6 +54,25 @@ impl WheelEvent {
     /// # Returns
     ///
     /// A new `WheelEvent` instance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uiohook_rs::hook::wheel::WheelEvent;
+    /// use uiohook_rs::hook::wheel::WHEEL_VERTICAL_DIRECTION;
+    /// use uiohook_rs::bindings;
+    ///
+    /// let wheel_event = WheelEvent::new(
+    ///     1,
+    ///     100,
+    ///     200,
+    ///     bindings::WHEEL_UNIT_SCROLL as u8,
+    ///     3,
+    ///     -120,
+    ///     WHEEL_VERTICAL_DIRECTION,
+    /// );
+    /// assert_eq!(wheel_event.clicks, 1);
+    /// ```
     pub fn new(clicks: u16, x: i16, y: i16, type_: u8, amount: u16, rotation: i16, direction: u8) -> Self {
         WheelEvent {
             clicks,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-//! uiohook-rs: Rust bindings for libuiohook
-//!
-//! This library provides a safe Rust interface to the libuiohook C library,
-//! allowing for cross-platform keyboard and mouse event hooking.
-//!
 //! # Example
 //!
 //! ```rust,no_run
@@ -30,16 +25,12 @@
 //!     };
 //!     let uiohook = Uiohook::new(event_handler);
 //!
-//!     if let Err(e) = uiohook.run() {
-//!         eprintln!("Failed to run uiohook: {}", e);
-//!         return;
-//!     }
+//!     uiohook.run().expect("Failed to run uiohook");
 //!
+//!     // Let the hook run for 5 seconds (in a real application, run a platform-specific event loop)
 //!     thread::sleep(Duration::from_secs(5));
 //!
-//!     if let Err(e) = uiohook.stop() {
-//!         eprintln!("Failed to stop uiohook: {}", e);
-//!     }
+//!     uiohook.stop().expect("Failed to stop uiohook");
 //! }
 //! ```
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,7 +46,7 @@ impl From<bindings::screen_data> for ScreenData {
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust,no_run
 /// use uiohook_rs::utils::create_screen_info;
 ///
 /// match create_screen_info() {


### PR DESCRIPTION
Bugs for blocked run loop for macOS when running the `pretty_demo`. Workaround but still will stop code execution afterwards.

```rust
    pub fn run(&self) -> Result<(), UiohookError> {
        if self.running.swap(true, Ordering::SeqCst) {
            return Err(UiohookError::AlreadyRunning);
        }
    
        GLOBAL_HANDLER.get_or_init(|| {
            ...
        });
    
        #[cfg(target_os = "macos")]
        {
            unsafe {
                // run in main thread, but will block code followed by it.
                bindings::hook_run();
            }
        }
    
        #[cfg(not(target_os = "macos"))]
        {
            let running = self.running.clone();
            let thread = std::thread::spawn(move || {
                while running.load(Ordering::SeqCst) {
                    ...
                }
            });
            *self.thread_handle.write().unwrap() = Some(thread);
        }
    
        Ok(())
    }
  
 ```